### PR TITLE
Performance boost

### DIFF
--- a/src/cerealed/cereal.d
+++ b/src/cerealed/cereal.d
@@ -86,7 +86,7 @@ void grain(C, T, U = ushort)(auto ref C cereal, ref T val) @trusted if(isCereali
     cereal.grain(length);
 
     static if(hasSlicing!(Unqual!T) && is(Unqual!(ElementType!T) : ubyte)) {
-        cereal.grainRaw(cast(ubyte[])val);
+        cereal.grainRaw(cast(ubyte[])val.array);
     }
     else
         foreach(ref e; val) cereal.grain(e);

--- a/src/cerealed/cerealiser.d
+++ b/src/cerealed/cerealiser.d
@@ -61,6 +61,10 @@ struct CerealiserImpl(R) if(isCerealiserRange!R) {
         }
     }
 
+    void grainRaw(ubyte[] val) @trusted {
+        _output.put(val);
+    }
+
     //specific:
     const(ubyte[]) bytes() const nothrow @property @safe {
         return _output.data;

--- a/src/cerealed/decerealiser.d
+++ b/src/cerealed/decerealiser.d
@@ -28,6 +28,12 @@ struct Decerealiser {
         grainClassImpl(this, val);
     }
 
+    auto grainRaw(size_t length) @safe {
+        auto res = _bytes[0..length];
+        _bytes = _bytes[length..$];
+        return res;
+    }
+
     //specific:
     this(T)(in T[] bytes) @safe if(isNumeric!T) {
         setBytes(bytes);

--- a/src/cerealed/range.d
+++ b/src/cerealed/range.d
@@ -13,6 +13,10 @@ struct DynamicArrayRange {
         _bytes ~= val;
     }
 
+    void put(in ubyte[] val) nothrow @safe {
+        _bytes ~= val;
+    }
+
     const(ubyte)[] data() pure const nothrow @property @safe {
         return _bytes;
     }


### PR DESCRIPTION
Hi,
as I worked on MQTT client library[0], I've found forum post about cerealed's speed[1], so I tried to make my "just mqtt" serialization as fast as msgpack and trying that I found some ways to improve performance of cerealed in specific cases and decided to make a PR for it.

I took your provided benchmark [2] and made some tuning for strings and byte arrays.

The test went from (DMD debug):
Cerealed: 5 secs, 926 ms, 824 μs, and 5 hnsecs
MsgPack:  2 secs, 226 ms, 575 μs, and 3 hnsecs

To:
Cerealed: 2 secs, 667 ms, 188 μs, and 3 hnsecs
MsgPack:  2 secs, 159 ms, 598 μs, and 1 hnsec

Which I like, so I hope this helps somehow. There are probably some other possible ways to tune it a bit more for other cases too.

[0] https://github.com/chalucha/vibe-mqtt
[1] http://forum.dlang.org/post/kceyzhlcumjxlfwbhcfr@forum.dlang.org
[2] http://dpaste.dzfl.pl/17b0ed9c0204