### PR TITLE
Convert test functions to unittest blocks

### DIFF
--- a/tests/bugs.d
+++ b/tests/bugs.d
@@ -10,7 +10,8 @@ private struct Pair {
 }
 
 
-void testAssocArrayWithPair() {
+@("assoc.array.with.pair")
+unittest {
     auto p = Pair("foo", 5);
     auto map = [p: 105];
     auto enc = Cerealiser();
@@ -25,7 +26,8 @@ void testAssocArrayWithPair() {
     map.values.shouldEqual(map2.values);
 }
 
-void testByteArray() {
+@("byte.array")
+unittest {
     ubyte[] arr = [1,2,3,4];
 
     auto enc = Cerealiser();

--- a/tests/cerealiser_impl.d
+++ b/tests/cerealiser_impl.d
@@ -9,7 +9,8 @@ struct WhateverStruct {
     string s;
 }
 
-void testOldCerealiser() {
+@("old.cerealiser")
+unittest {
     auto enc = DynamicArrayCerealiser();
     enc ~= WhateverStruct(5, "blargh");
     enc.bytes.shouldEqual([ 0, 5, 0, 6, 'b', 'l', 'a', 'r', 'g', 'h' ]);
@@ -18,7 +19,8 @@ void testOldCerealiser() {
     (enc ~= 4).shouldNotThrow!RangeError;
 }
 
-void testScopeBufferCerealiser() {
+@("scope.buffer.cerealiser")
+unittest {
     ubyte[32] buf = void;
 
     writelnUt("Creating the range");
@@ -34,6 +36,7 @@ void testScopeBufferCerealiser() {
 }
 
 
-void testCerealise() {
+@("cerealise")
+unittest {
    WhateverStruct(5, "blargh").cerealise!(bytes => bytes.shouldEqual([0, 5, 0, 6, 'b', 'l', 'a', 'r', 'g', 'h']));
 }

--- a/tests/classes.d
+++ b/tests/classes.d
@@ -11,7 +11,8 @@ private class DummyClass {
     }
 }
 
-void testDummyClass() {
+@("dummy.class")
+unittest {
     auto enc = Cerealiser();
     auto dummy = new DummyClass();
     enc ~= dummy;
@@ -37,7 +38,8 @@ private class ClassWithStruct {
     }
 }
 
-void testClassWithStruct() {
+@("class.with.struct")
+unittest {
     auto enc = Cerealiser();
     auto klass = new ClassWithStruct(DummyStruct(2, 3), 4);
     enc ~= klass;
@@ -74,7 +76,8 @@ class DerivedClass: BaseClass {
     }
 }
 
-void testDerivedClass() {
+@("derived.class")
+unittest {
     auto enc = Cerealiser();
     auto klass = new DerivedClass(2, 4, 8, 9);
     enc ~= klass;
@@ -86,7 +89,8 @@ void testDerivedClass() {
 }
 
 
-void testSerialisationViaBaseClass() {
+@("serialisation.via.base.class")
+unittest {
     BaseClass klass = new DerivedClass(2, 4, 8, 9);
     const baseBytes = [2, 4];
     const childBytes = [2, 4, 8, 9];

--- a/tests/compile_time.d
+++ b/tests/compile_time.d
@@ -17,7 +17,8 @@ private struct RightStruct {
     @Bits!32 uint ui;
 }
 
-void testBitsTooBig() {
+@("bits.too.big")
+unittest {
     static assert(!is(typeof(() { auto c = Cerealiser(); c ~= WrongStruct1(3); })));
     static assert(!is(typeof(() { auto c = Cerealiser(); c ~= WrongStruct2(3); })));
     static assert(is(typeof(() { auto c = Cerealiser(); c ~= RightStruct(3); })));

--- a/tests/decode.d
+++ b/tests/decode.d
@@ -4,7 +4,8 @@ import unit_threaded;
 import cerealed.decerealiser;
 import core.exception;
 
-void testDecodeBool() {
+@("decode.bool")
+unittest {
     import cerealed.cereal: grain;
     auto cereal = Decerealiser([1, 0, 1, 0, 0, 1]);
     bool val;
@@ -18,7 +19,8 @@ void testDecodeBool() {
 }
 
 
-void testDecodeByte() {
+@("decode.byte")
+unittest {
     auto cereal = Decerealiser([0x0, 0x2, 0xfc]);
     cereal.value!byte.shouldEqual(0);
     cereal.value!byte.shouldEqual(2);
@@ -26,7 +28,8 @@ void testDecodeByte() {
     cereal.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
-void testDecodeRefByte() {
+@("decode.ref.byte")
+unittest {
     import cerealed.cereal: grain;
     auto cereal = Decerealiser([0xfc]);
     byte val;
@@ -34,7 +37,8 @@ void testDecodeRefByte() {
     val.shouldEqual(-4);
 }
 
-void testDecodeUByte() {
+@("decode.u.byte")
+unittest {
     auto cereal = Decerealiser([0x0, 0x2, 0xfc]);
     cereal.value!ubyte.shouldEqual(0);
     cereal.value!ubyte.shouldEqual(2);
@@ -42,14 +46,16 @@ void testDecodeUByte() {
     cereal.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
-void testDecodeShort() {
+@("decode.short")
+unittest {
     auto cereal = Decerealiser([0xff, 0xfe, 0x0, 0x3]);
     cereal.value!short.shouldEqual(-2);
     cereal.value!short.shouldEqual(3);
     shouldThrow!RangeError(cereal.value!short); //no more bytes
 }
 
-void testDecodeRefShort() {
+@("decode.ref.short")
+unittest {
     import cerealed.cereal: grain;
     auto cereal = Decerealiser([0xff, 0xfe]);
     short val;
@@ -57,13 +63,15 @@ void testDecodeRefShort() {
     val.shouldEqual(-2);
 }
 
-void testDecodeInt() {
+@("decode.int")
+unittest {
     auto cereal = Decerealiser([ 0xff, 0xf0, 0xbd, 0xc0]);
     cereal.value!int.shouldEqual(-1_000_000);
     shouldThrow!RangeError(cereal.value!int); //no more bytes
 }
 
-void testDecodeRefInt() {
+@("decode.ref.int")
+unittest {
     import cerealed.cereal: grain;
     auto cereal = Decerealiser([0xff, 0xf0, 0xbd, 0xc0]);
     int val;
@@ -71,14 +79,16 @@ void testDecodeRefInt() {
     val.shouldEqual(-1_000_000);
 }
 
-void testDecodeLong() {
+@("decode.long")
+unittest {
     auto cereal = Decerealiser([ 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2]);
     cereal.value!long.shouldEqual(1);
     cereal.value!long.shouldEqual(2);
     cereal.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
-void testDecodeRefLong() {
+@("decode.ref.long")
+unittest {
     import cerealed.cereal: grain;
     auto cereal = Decerealiser([ 0, 0, 0, 0, 0, 0, 0, 1]);
     long val;
@@ -87,21 +97,24 @@ void testDecodeRefLong() {
 }
 
 
-void testDecodeBigULong() {
+@("decode.big.u.long")
+unittest {
     auto dec = Decerealiser([0xd8, 0xbf, 0xc7, 0xcd, 0x2d, 0x9b, 0xa1, 0xb1]);
     dec.value!ulong.shouldEqual(0xd8bfc7cd2d9ba1b1);
     shouldThrow!RangeError(dec.value!ubyte); //no more bytes
 }
 
 
-void testDecodeDouble() {
+@("decode.double")
+unittest {
     auto cereal = Decerealiser([ 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2]);
     shouldNotThrow(cereal.value!double);
     shouldNotThrow(cereal.value!double);
     cereal.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
-void testDecodeChars() {
+@("decode.chars")
+unittest {
     auto cereal = Decerealiser([ 0xff, 0xff, 0xff, 0x00, 0x00, 0xff, 0xff ]);
     cereal.value!char.shouldEqual(0xff);
     cereal.value!wchar.shouldEqual(0xffff);
@@ -109,7 +122,8 @@ void testDecodeChars() {
     cereal.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
-void testDecodeRefChar() {
+@("decode.ref.char")
+unittest {
     import cerealed.cereal: grain;
     auto cereal = Decerealiser([0xff]);
     char val;
@@ -118,13 +132,15 @@ void testDecodeRefChar() {
 }
 
 
-void testDecodeArray() {
+@("decode.array")
+unittest {
     auto cereal = Decerealiser([ 0, 3, 0, 0, 0, 2, 0, 0, 0, 6, 0, 0, 0, 9 ]);
     cereal.value!(int[]).shouldEqual([ 2, 6, 9 ]);
     cereal.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
-void testDecodeRefArray() {
+@("decode.ref.array")
+unittest {
     import cerealed.cereal: grain;
     auto cereal = Decerealiser([0, 1, 0, 0, 0, 2]);
     int[] val;
@@ -132,20 +148,23 @@ void testDecodeRefArray() {
     val.shouldEqual([2]);
 }
 
-void testDecodeArrayLongLength() {
+@("decode.array.long.length")
+unittest {
     auto cereal = Decerealiser([ 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 2, 0, 0, 0, 6, 0, 0, 0, 9 ]);
     cereal.value!(int[], long).shouldEqual([ 2, 6, 9 ]);
     cereal.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
-void testDecodeAssocArray() {
+@("decode.assoc.array")
+unittest {
     auto cereal = Decerealiser([ 0, 2, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 6 ]);
     cereal.value!(int[int]).shouldEqual([ 1:2, 3:6]);
     cereal.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
 
-void testDecodeRefAssocArray() {
+@("decode.ref.assoc.array")
+unittest {
     import cerealed.cereal: grain;
     auto cereal = Decerealiser([0, 1, 0, 0, 0, 2, 0, 0, 0, 3]);
     int[int] val;
@@ -153,19 +172,22 @@ void testDecodeRefAssocArray() {
     val.shouldEqual([2:3]);
 }
 
-void testDecodeAssocArrayIntLength() {
+@("decode.assoc.array.int.length")
+unittest {
     auto cereal = Decerealiser([ 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 6 ]);
     cereal.value!(int[int], int).shouldEqual([ 1:2, 3:6]);
     cereal.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
-void testDecodeString() {
+@("decode.string")
+unittest {
     auto cereal = Decerealiser([0, 5, 'a', 't', 'o', 'y', 'n']);
     cereal.value!(string).shouldEqual("atoyn");
     cereal.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
-void testDecodeRefString() {
+@("decode.ref.string")
+unittest {
     import cerealed.cereal: grain;
     auto cereal = Decerealiser([0, 5, 'a', 't', 'o', 'y', 'n']);
     string val;
@@ -174,7 +196,8 @@ void testDecodeRefString() {
     cereal.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
-void testDecodeBits() {
+@("decode.bits")
+unittest {
     auto cereal = Decerealiser([ 0x9e, 0xea]);
     //1001 1110 1110 1010 or
     //100 111 10111 01 010
@@ -192,13 +215,15 @@ void testDecodeBits() {
     cereal.readBits(3).shouldEqual(2);
 }
 
-void testDecodeBitsMultiByte() {
+@("decode.bits.multi.byte")
+unittest {
     auto cereal = Decerealiser([ 0x9e, 0xea]);
     cereal.readBits(9).shouldEqual(317);
     cereal.readBits(7).shouldEqual(0x6a);
 }
 
-void testDecodeStringArray() {
+@("decode.string.array")
+unittest {
     auto dec = Decerealiser([ 0, 3,
                               0, 3, 'f', 'o', 'o',
                               0, 4, 'w', '0', '0', 't',
@@ -233,7 +258,8 @@ unittest {
 }
 
 @("Types with @disable this can be encoded/decoded")
-@safe unittest {
+@safe
+unittest {
     static struct NoDefault {
         ubyte i;
         @disable this();

--- a/tests/encode.d
+++ b/tests/encode.d
@@ -4,7 +4,8 @@ import unit_threaded;
 import cerealed.cerealiser;
 
 
-void testEncodeBool() {
+@("encode.bool")
+unittest {
     auto cereal = Cerealiser();
     cereal.write(false);
     cereal.write(true);
@@ -15,56 +16,64 @@ void testEncodeBool() {
     cereal.bytes.shouldEqual([ 0x0, 0x1, 0x0, 0x1 ]);
 }
 
-void testEncodeByte() {
+@("encode.byte")
+unittest {
     auto cereal = Cerealiser();
     byte[] ins = [ 1, 3, -2, 5, -4];
     foreach(i; ins) cereal.write(i);
     cereal.bytes.shouldEqual([ 0x1, 0x3, 0xfe, 0x5, 0xfc ]);
 }
 
-void testEncodeUByte() {
+@("encode.u.byte")
+unittest {
     auto cereal = Cerealiser();
     ubyte[] ins = [ 2, 3, 12, 10];
     foreach(i; ins) cereal ~= i;
     cereal.bytes.shouldEqual([ 0x2, 0x3, 0xc, 0xa ]);
 }
 
-void testEncodeShort() {
+@("encode.short")
+unittest {
     auto cereal = Cerealiser();
     short[] ins = [ -2, 3, -32767, 0];
     foreach(i; ins) cereal ~= i;
     cereal.bytes.shouldEqual([ 0xff, 0xfe, 0x0, 0x3, 0x80, 0x01, 0x0, 0x0 ]);
 }
 
-void testEncodeUShort() {
+@("encode.u.short")
+unittest {
     auto cereal = Cerealiser();
     ushort[] ins = [ 2, 3, cast(short)65535, 0];
     foreach(i; ins) cereal ~= i;
     cereal.bytes.shouldEqual([ 0x0, 0x2, 0x0, 0x3, 0xff, 0xff, 0x0, 0x0 ]);
 }
 
-void testEncodeInt() {
+@("encode.int")
+unittest {
     auto cereal = Cerealiser();
     int[] ins = [ 3, -1_000_000];
     foreach(i; ins) cereal ~= i;
     cereal.bytes.shouldEqual([ 0x0, 0x0, 0x0, 0x3, 0xff, 0xf0, 0xbd, 0xc0 ]);
 }
 
-void testEncodeUInt() {
+@("encode.u.int")
+unittest {
     auto cereal = Cerealiser();
     uint[] ins = [ 1_000_000, 0];
     foreach(i; ins) cereal ~= i;
     cereal.bytes.shouldEqual([ 0x0, 0x0f, 0x42, 0x40, 0x0, 0x0, 0x0, 0x0 ]);
 }
 
-void testEncodeLong() {
+@("encode.long")
+unittest {
     auto cereal = Cerealiser();
     long[] ins = [1, 2];
     foreach(i; ins) cereal ~= i;
     cereal.bytes.shouldEqual([ 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2]);
 }
 
-void testEncodeULong() {
+@("encode.u.long")
+unittest {
     auto cereal = Cerealiser();
     cereal ~= 45L;
     cereal.bytes.shouldEqual([ 0, 0, 0, 0, 0, 0, 0, 45 ]);
@@ -74,24 +83,28 @@ void testEncodeULong() {
     cereal.bytes.shouldEqual([ 0, 0, 0, 0, 0, 0, 0, 42 ]);
 }
 
-void testEncodeBigULong() {
+@("encode.big.u.long")
+unittest {
     ulong val = 0xd8bfc7cd2d9ba1b1;
     auto enc = Cerealiser();
     enc ~= val;
     enc.bytes.shouldEqual([0xd8, 0xbf, 0xc7, 0xcd, 0x2d, 0x9b, 0xa1, 0xb1]);
 }
 
-void testEncodeFloat() {
+@("encode.float")
+unittest {
     auto cereal = Cerealiser();
     cereal ~= 1.0f;
 }
 
-void testEncodeDouble() {
+@("encode.double")
+unittest {
     auto cereal = Cerealiser();
     cereal ~= 1.0;
 }
 
-void testEncodeChars() {
+@("encode.chars")
+unittest {
     auto cereal = Cerealiser();
     char  c; cereal ~= c;
     wchar w; cereal ~= w;
@@ -99,7 +112,8 @@ void testEncodeChars() {
     cereal.bytes.shouldEqual([ 0xff, 0xff, 0xff, 0x00, 0x00, 0xff, 0xff]);
 }
 
-void testEncodeArray() {
+@("encode.array")
+unittest {
     auto cereal = Cerealiser();
     const ints = [ 2, 6, 9];
     cereal ~= ints;
@@ -107,7 +121,8 @@ void testEncodeArray() {
     cereal.bytes.shouldEqual([ 0, 3, 0, 0, 0, 2, 0, 0, 0, 6, 0, 0, 0, 9]);
 }
 
-void testEncodeAssocArray() {
+@("encode.assoc.array")
+unittest {
     import std.algorithm;
 
     auto cereal = Cerealiser();
@@ -122,7 +137,8 @@ void testEncodeAssocArray() {
     cereal.bytes.canFind([0, 0, 0, 3, /*:*/ 0, 0, 0, 6,]).shouldBeTrue;
 }
 
-void testEncodeString() {
+@("encode.string")
+unittest {
     auto cereal = Cerealiser();
     const str = "foobarbaz";
     cereal ~= str;
@@ -130,14 +146,16 @@ void testEncodeString() {
     cereal.bytes.shouldEqual([ 0, 9, 'f', 'o', 'o', 'b', 'a', 'r', 'b', 'a', 'z' ]);
 }
 
-void testEncodeNibble() {
+@("encode.nibble")
+unittest {
     auto cereal = Cerealiser();
     cereal.writeBits(0x4, 4);
     cereal.writeBits(0xf, 4);
     cereal.bytes.shouldEqual([ 0x4f ]);
 }
 
-void testEncodeSubByte() {
+@("encode.sub.byte")
+unittest {
     auto cereal = Cerealiser();
     cereal.writeBits(1, 1);
     cereal.writeBits(3, 2);
@@ -147,7 +165,8 @@ void testEncodeSubByte() {
     cereal.bytes.shouldEqual([ 0xeb]);
 }
 
-void testEncodeSubWord() {
+@("encode.sub.word")
+unittest {
     auto cereal = Cerealiser();
     cereal.writeBits(4, 3);
     cereal.writeBits(7, 3);
@@ -157,7 +176,8 @@ void testEncodeSubWord() {
     cereal.bytes.shouldEqual([ 0x9e, 0xea]);
 }
 
-void testEncodeMoreThan8Bits() {
+@("encode.more.than8.bits")
+unittest {
     {
         auto cereal = Cerealiser();
         cereal.writeBits(1, 9);
@@ -172,7 +192,8 @@ void testEncodeMoreThan8Bits() {
     }
 }
 
-void testEncodeFailsIfTooBigForBits() {
+@("encode.fails.if.too.big.for.bits")
+unittest {
     auto cereal = Cerealiser();
     shouldNotThrow(cereal.writeBits(1, 1));
     shouldThrow(cereal.writeBits(2, 1));
@@ -180,7 +201,8 @@ void testEncodeFailsIfTooBigForBits() {
     shouldThrow(cereal.writeBits(5, 2));
 }
 
-void testEncodeTwoBytesBits() {
+@("encode.two.bytes.bits")
+unittest {
     auto cereal = Cerealiser();
     immutable uint value = 5;
     cereal.writeBits(3, 4);
@@ -192,13 +214,15 @@ void testEncodeTwoBytesBits() {
 }
 
 
-void testCerealise() {
+@("cerealise")
+unittest {
     cerealise(4).shouldEqual([0, 0, 0, 4]);
     cerealize("foo").shouldEqual([0, 3, 'f', 'o', 'o']);
 }
 
 @("struct with no default ctor")
-@safe pure unittest {
+@safe pure
+unittest {
     static struct NoDefault {
         ubyte i;
         @disable this();

--- a/tests/encode_decode.d
+++ b/tests/encode_decode.d
@@ -20,7 +20,8 @@ private void implEncDec(T)(T[] values) {
     dec.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
-void testEncDecBool() {
+@("enc.dec.bool")
+unittest {
     implEncDec([ true, true, false, false, true]);
 }
 
@@ -30,47 +31,58 @@ private void implEncDecValues(T, alias arr)() {
     implEncDec(values);
 }
 
-void testEncDecByte() {
+@("enc.dec.byte")
+unittest {
     implEncDecValues!(byte, [ 1, 3, -2, 5, -4 ]);
 }
 
-void testEncDecUByte() {
+@("enc.dec.u.byte")
+unittest {
     implEncDecValues!(ubyte, [ 1, 255, 12 ]);
 }
 
-void testEncDecShort() {
+@("enc.dec.short")
+unittest {
     implEncDecValues!(short, [ 1, -2, -32768, 5 ]);
 }
 
-void testEncDecUShort() {
+@("enc.dec.u.short")
+unittest {
     implEncDecValues!(short, [ 1, -2, 32767, 5 ]);
 }
 
-void testEncDecInt() {
+@("enc.dec.int")
+unittest {
     implEncDecValues!(int, [ 1, -2, -1_000_000, 2_000_000 ]);
 }
 
-void testEncDecUInt() {
+@("enc.dec.u.int")
+unittest {
    implEncDecValues!(uint, [ 1, -2, 1_000_000, 2_000_000 ]);
 }
 
-void testEncDecLong() {
+@("enc.dec.long")
+unittest {
     implEncDecValues!(long, [ 5_000_000, 2, -3, -5_000_000_000, 1 ]);
 }
 
-void testEncDecULong() {
+@("enc.dec.u.long")
+unittest {
     implEncDecValues!(ulong, [ 5_000_000, 2, 7_000_000_000, 1 ]);
 }
 
-void testEncDecFloat() {
+@("enc.dec.float")
+unittest {
     implEncDec([ 2.0f, -4.3f, 3.1415926f ]); //don't add a value without 'f'!
 }
 
-void testEncDecDouble() {
+@("enc.dec.double")
+unittest {
     implEncDec([ 2.0, -9.0 ]);
 }
 
-void testEncDecChars() {
+@("enc.dec.chars")
+unittest {
     char c = 5;
     wchar w = 300;
     dchar d = 1_000_000;
@@ -83,7 +95,8 @@ void testEncDecChars() {
     dec.value!ubyte.shouldThrow!RangeError; //no more bytes
 }
 
-void testEncDecArray() {
+@("enc.dec.array")
+unittest {
     auto enc = Cerealiser();
     const ints = [ 2, 6, 9];
     enc ~= ints;
@@ -93,7 +106,8 @@ void testEncDecArray() {
 }
 
 
-@("struct with @LengthType") unittest {
+@("struct with @LengthType")
+unittest {
     import cerealed.attrs: LengthType;
     struct Foo {
         @LengthType!ubyte ushort[] arr;
@@ -107,7 +121,8 @@ void testEncDecArray() {
     dec.value!Foo.shouldEqual(foo);
 }
 
-void testEncDecAssocArray() {
+@("enc.dec.assoc.array")
+unittest {
     auto enc = Cerealiser();
     const intToInts = [ 1:2, 3:6, 9:18];
     enc ~= intToInts;

--- a/tests/enums.d
+++ b/tests/enums.d
@@ -7,7 +7,8 @@ import core.exception;
 
 private enum MyEnum { Foo, Bar, Baz };
 
-void testEnum() {
+@("enum")
+unittest {
     auto enc = Cerealiser();
     enc ~= MyEnum.Bar;
     enc ~= MyEnum.Baz;
@@ -21,7 +22,8 @@ void testEnum() {
     dec.value!ubyte.shouldThrow!RangeError;
 }
 
-void testDecodeEnum() {
+@("decode.enum")
+unittest {
     enum Foo : ubyte {
         Bar = 0,
         Baz = 1

--- a/tests/multidimensional_array.d
+++ b/tests/multidimensional_array.d
@@ -4,7 +4,8 @@ import unit_threaded;
 import cerealed;
 
 
-void testEmptyMultidimensionalArray() {
+@("empty.multidimensional.array")
+unittest {
     int[][] original, restored;
     auto enc = Cerealiser();
     enc ~= original;
@@ -14,7 +15,8 @@ void testEmptyMultidimensionalArray() {
 }
 
 
-void testMultidimensionalArray() {
+@("multidimensional.array")
+unittest {
     int[][] some = [
         [3, 5, 6],
         [-3, 6, int.max, int.min],

--- a/tests/nested.d
+++ b/tests/nested.d
@@ -13,7 +13,8 @@ struct SomeStruct {
     Nested[] nesteds;
 }
 
-void testEmptyNested() {
+@("empty.nested")
+unittest {
     SomeStruct original, restored;
     auto enc = Cerealiser();
     enc ~= original;
@@ -24,7 +25,8 @@ void testEmptyNested() {
 }
 
 
-void testNested() {
+@("nested")
+unittest {
     auto some = SomeStruct(["foo", "sunny"],
                            [[2, 4], [1, 3, 5]],
                            [Nested([7: Nested()])]);
@@ -37,7 +39,8 @@ void testNested() {
     dec.value!SomeStruct.shouldEqual(some);
 }
 
-void testNestedDynamic() {
+@("nested.dynamic")
+unittest {
     SomeStruct[] some;
     some ~= SomeStruct(["foo", "sunny"],
                        [[2, 4], [1, 3, 5]],

--- a/tests/pointers.d
+++ b/tests/pointers.d
@@ -16,7 +16,8 @@ private struct OuterStructWithPointerToStruct {
     ubyte b;
 }
 
-void testStructWithPointerToStruct() {
+@("struct.with.pointer.to.struct")
+unittest {
     auto enc = Cerealiser();
     //outer not const because not copyable from const
     auto outer = OuterStructWithPointerToStruct(3, new InnerStruct(7, 2), 5);
@@ -57,7 +58,8 @@ private struct OuterStructWithClass {
     ubyte b;
 }
 
-void testStructWithClassReference() {
+@("struct.with.class.reference")
+unittest {
     auto enc = Cerealiser();
     auto outer = OuterStructWithClass(2, new InnerClass(3, 5), 8);
     enc ~= outer;
@@ -76,7 +78,8 @@ void testStructWithClassReference() {
     decOuter.b.shouldEqual(outer.b);
 }
 
-void testPointerToInt() {
+@("pointer.to.int")
+unittest {
     auto enc = Cerealiser();
     auto i = new int; *i = 4;
     enc ~= i;

--- a/tests/protocol_unit.d
+++ b/tests/protocol_unit.d
@@ -20,7 +20,8 @@ struct Packet {
 }
 
 
-void testUnits() {
+@("units")
+unittest {
     ubyte[] bytes = [3, 0, 4, 9, 0, 7, 1, 2, 0, 6, 2, 3, 0, 5, 4, 5, 0, 4, 9, 8];
     auto pkt = decerealise!Packet(bytes);
 
@@ -53,7 +54,8 @@ struct PacketWithArrayLengthExpr {
     @ArrayLength("length - headerSize") Unit[] units;
 }
 
-void testArrayLengthExpr() {
+@("array.length.expr")
+unittest {
     immutable ubyte[] bytes = [3, 0, 7, 0, 8, //header
                                0, 7, 1, 2,
                                0, 6, 2, 3,
@@ -80,13 +82,15 @@ struct NegativeStruct {
     @ArrayLength("len") Unit[] units;
 }
 
-void testNegativeLength() {
+@("negative.length")
+unittest {
     immutable ubyte[] bytes = [1, 2, 3, 4, 5];
     decerealise!NegativeStruct(bytes).shouldThrow!CerealException;
 }
 
 
-void testNotEnoughBytes() {
+@("not.enough.bytes")
+unittest {
     immutable ubyte[] bytes = [3, 0, 7, 0, 8, //header
                                0, 7]; //truncated
     decerealise!PacketWithArrayLengthExpr(bytes).shouldThrow!CerealException;
@@ -106,7 +110,8 @@ struct PacketWithLengthInBytes {
     @LengthInBytes("lengthNoHeader - headerSize") Unit[] units;
 }
 
-void testLengthInBytes() {
+@("length.in.bytes")
+unittest {
     immutable ubyte[] bytes = [ 7, 0, 11, //header (11 bytes = hdr + 2 units of 4 bytes each)
                                 0, 3, 1, 2,
                                 0, 9, 3, 4,
@@ -142,7 +147,8 @@ struct BigUnitPacket {
     @LengthInBytes("totalLength - headerSize") BigUnit[] units;
 }
 
-void testLengthInBytesOneUnit() {
+@("length.in.bytes.one.unit")
+unittest {
     immutable ubyte[] bytes = [ 0, 10, //totalLength = 1 unit of size 8 + header size of 1
                                 0, 0, 0, 1, 0, 0, 0, 2
         ];

--- a/tests/range.d
+++ b/tests/range.d
@@ -6,7 +6,8 @@ import std.range;
 import core.exception;
 
 
-void testInputRange() {
+@("input.range")
+unittest {
     auto enc = Cerealiser();
     enc ~= iota(cast(ubyte)5);
     enc.bytes.shouldEqual([0, 5, 0, 1, 2, 3, 4]);
@@ -20,12 +21,14 @@ private struct MyOutputRange {
     }
 }
 
-void testMyOutputRange() {
+@("my.output.range")
+unittest {
     static assert(isOutputRange!(MyOutputRange, ubyte));
 }
 
+@("output.range.value")
 @SingleThreaded
-void testOutputRangeValue() {
+unittest {
     gOutputBytes = [];
 
     auto dec = Decerealiser([0, 5, 2, 3, 9, 6, 1]);
@@ -34,8 +37,9 @@ void testOutputRangeValue() {
     gOutputBytes.shouldEqual([2, 3, 9, 6, 1]);
 }
 
+@("output.range.read")
 @SingleThreaded
-void testOutputRangeRead() {
+unittest {
     gOutputBytes = [];
 
     auto dec = Decerealiser([0, 5, 2, 3, 9, 6, 1]);
@@ -62,8 +66,9 @@ private struct StructWithInputRange {
     MyInputRange input;
 }
 
+@("embedded.input.range")
 @SingleThreaded
-void testEmbeddedInputRange() {
+unittest {
     auto enc = Cerealiser();
     auto str = StructWithInputRange(2, MyInputRange([9, 7, 6]));
     enc ~= str;
@@ -82,8 +87,9 @@ private struct StructWithOutputRange {
     ubyte b2;
 }
 
+@("embedded.output.range")
 @SingleThreaded
-void testEmbeddedOutputRange() {
+unittest {
     auto enc = Cerealiser();
     enum compiles = __traits(compiles, { enc ~= StructWithOutputRange(); });
     static assert(!compiles, "Should not be able to read from an OutputRange");

--- a/tests/reset.d
+++ b/tests/reset.d
@@ -5,7 +5,8 @@ import cerealed.cerealiser;
 import cerealed.decerealiser;
 
 
-void testResetCerealiser() {
+@("reset.cerealiser")
+unittest {
     auto enc = Cerealiser();
     enc ~= 5;
     enc ~= 'a';
@@ -23,7 +24,8 @@ void testResetCerealiser() {
 }
 
 
-void testResetDecerealiser() {
+@("reset.decerealiser")
+unittest {
     const ubyte[] bytes1 = [1, 2, 3, 5, 8, 13];
     auto dec = Decerealiser(bytes1);
 
@@ -42,7 +44,8 @@ void testResetDecerealiser() {
 }
 
 
-void testEmptyDecerealiser() {
+@("empty.decerealiser")
+unittest {
     import core.exception: RangeError;
     auto dec = Decerealiser();
     dec.value!ubyte.shouldThrow!RangeError; //no bytes

--- a/tests/static_array.d
+++ b/tests/static_array.d
@@ -3,7 +3,8 @@ module tests.static_array;
 import unit_threaded;
 import cerealed;
 
-void testStaticArray() {
+@("static.array")
+unittest {
     int[2] original, restored;
 
     original[0] = 34;
@@ -22,7 +23,8 @@ void testStaticArray() {
 }
 
 
-void testArrayOfArrays() {
+@("array.of.arrays")
+unittest {
     static struct Unit {
         ubyte thingie;
         ushort length;

--- a/tests/structs.d
+++ b/tests/structs.d
@@ -18,7 +18,8 @@ private struct DummyStruct {
 }
 
 
-void testDummyStruct() {
+@("dummy.struct")
+unittest {
     auto enc = Cerealiser();
     auto dummy = DummyStruct(5, 6.0, [2, 3], true, [2: 4.0], "dummy!");
     enc ~= dummy;
@@ -33,7 +34,8 @@ private struct StringStruct {
     string s;
 }
 
-void testDecodeStringStruct() {
+@("decode.string.struct")
+unittest {
     auto dec = Decerealiser([0, 3, 'f', 'o', 'o']);
     auto str = StringStruct();
     dec.grain(str);
@@ -41,7 +43,8 @@ void testDecodeStringStruct() {
     dec.value!ubyte.shouldThrow!RangeError;
 }
 
-void testEncodeStringStruct() {
+@("encode.string.struct")
+unittest {
     auto enc = Cerealiser();
     const str = StringStruct("foo");
     enc ~= str;
@@ -57,7 +60,8 @@ private struct ProtoHeaderStruct {
 }
 
 
-void testEncDecProtoHeaderStruct() {
+@("enc.dec.proto.header.struct")
+unittest {
     const hdr = ProtoHeaderStruct(6, 1, 3, 254);
     auto enc = Cerealiser();
     enc ~= hdr; //1101 0011, 254
@@ -75,7 +79,8 @@ private struct StructWithNoCereal {
     @NoCereal ushort nocereal2;
 }
 
-void testNoCereal() {
+@("no.cereal")
+unittest {
     auto cerealizer = Cerealizer();
     cerealizer ~= StructWithNoCereal(3, 14, 42, 5, 12);
     //only nibble1, nibble2 and value should show up in bytes
@@ -99,7 +104,8 @@ private struct CustomStruct {
     }
 }
 
-void testCustomCereal() {
+@("custom.cereal")
+unittest {
     auto cerealiser = Cerealiser();
     cerealiser ~= CustomStruct(1, 2);
     cerealiser.bytes.shouldEqual([ 1, 0, 2, 4]);
@@ -110,7 +116,8 @@ void testCustomCereal() {
 }
 
 
-void testAttrMember() {
+@("attr.member")
+unittest {
     //test that attributes work when calling grain member by member
     auto cereal = Cerealizer();
     auto str = StructWithNoCereal(3, 14, 42, 5, 12);
@@ -135,7 +142,8 @@ struct EnumStruct {
     Enum bar;
 }
 
-void testEnum() {
+@("enum")
+unittest {
     auto cerealiser = Cerealiser();
     const e = EnumStruct(1, EnumStruct.Enum.Baz);
     cerealiser ~= e;
@@ -156,7 +164,8 @@ struct PostBlitStruct {
     }
 }
 
-void testPostBlit() {
+@("post.blit")
+unittest {
     auto enc = Cerealiser();
     enc ~= PostBlitStruct(3, 5, 8);
     const bytes = [ 3, 8, 0, 4];
@@ -171,7 +180,8 @@ private struct StringsStruct {
     @RawArray string[] strings;
 }
 
-void testRawArray() {
+@("raw.array")
+unittest {
     auto enc = Cerealiser();
     auto strs = StringsStruct(5, ["foo", "foobar", "ohwell"]);
     enc ~= strs;
@@ -184,7 +194,8 @@ void testRawArray() {
     dec.value!StringsStruct.shouldEqual(strs);
 }
 
-void testReadmeCode() {
+@("readme.code")
+unittest {
     struct MyStruct {
         ubyte mybyte1;
         @NoCereal uint nocereal1; //won't be serialised
@@ -266,7 +277,8 @@ private:
     }
 }
 
-void testAcceptPostBlitAttrs() {
+@("accept.post.blit.attrs")
+unittest {
     import cerealed.traits;
     static assert(hasPostBlit!MqttFixedHeader);
     static assert(hasAccept!CustomStruct);
@@ -275,13 +287,15 @@ void testAcceptPostBlitAttrs() {
 
 }
 
-void testCerealiseMqttHeader() {
+@("cerealise.mqtt.header")
+unittest {
     auto cereal = Cerealiser();
     cereal ~= MqttFixedHeader(MqttType.PUBLISH, true, 2, false, 5);
     cereal.bytes.shouldEqual([0x3c, 0x5]);
 }
 
-void testDecerealiseMqttHeader() {
+@("decerealise.mqtt.header")
+unittest {
     auto cereal = Decerealiser([0x3c, 0x5]);
     cereal.value!MqttFixedHeader.shouldEqual(MqttFixedHeader(MqttType.PUBLISH, true, 2, false, 5));
 }
@@ -317,7 +331,8 @@ struct StructWithPreBlit {
     mixin assertHasPreBlit!StructWithPreBlit;
 }
 
-void testPreBlit() {
+@("pre.blit")
+unittest {
     immutable ubyte[] bytesOk = [0, 0, 0, 3, 1, 2];
     bytesOk.decerealise!StructWithPreBlit;
 

--- a/tests/utils.d
+++ b/tests/utils.d
@@ -11,7 +11,8 @@ struct SimpleStruct {
     ushort us2;
 }
 
-void testSizeofSimpleStruct() {
+@("sizeof.simple.struct")
+unittest {
     unalignedSizeof!SimpleStruct.shouldEqual(5);
 }
 
@@ -20,7 +21,8 @@ struct Outer {
     SimpleStruct inner;
 }
 
-void testSizeOfStructWithStructs() {
+@("size.of.struct.with.structs")
+unittest {
     unalignedSizeof!Outer.shouldEqual(5);
 }
 
@@ -30,7 +32,8 @@ union Union {
     ushort us;
 }
 
-void testSizeOfUnion() {
+@("size.of.union")
+unittest {
     unalignedSizeof!Union.shouldEqual(2);
 }
 
@@ -40,6 +43,7 @@ class Class {
     ushort us;
 }
 
-void testSizeOfClass() {
+@("size.of.class")
+unittest {
     unalignedSizeof!Class.shouldEqual(3);
 }


### PR DESCRIPTION
## Summary

- Converts all 118 named test functions (`void testFooBar()`) to `@("foo.bar") unittest` blocks, which is the format supported by modern unit-threaded
- camelCase function names are split on capital letters and joined with dots, lowercased (e.g. `testEncDecULong` → `@("enc.dec.u.long")`)
- Preserves existing UDAs like `@SingleThreaded` on the `unittest` line
- All 156 tests pass after the conversion

## Test plan

- [x] `dub test` — 156 tests, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)